### PR TITLE
chore: rename ks to ts

### DIFF
--- a/contracts/transmuter/configs/Production.sol
+++ b/contracts/transmuter/configs/Production.sol
@@ -94,9 +94,9 @@ contract Production {
 
         Setters.setAccessControlManager(_accessControlManager);
 
-        TransmuterStorage storage ks = s.transmuterStorage();
-        ks.normalizer = uint128(BASE_27);
-        ks.agToken = IAgToken(_agToken);
+        TransmuterStorage storage ts = s.transmuterStorage();
+        ts.normalizer = uint128(BASE_27);
+        ts.agToken = IAgToken(_agToken);
 
         // Setup each collaterals
         for (uint256 i; i < collaterals.length; i++) {

--- a/contracts/transmuter/configs/Test.sol
+++ b/contracts/transmuter/configs/Test.sol
@@ -27,9 +27,9 @@ contract Test {
     ) external {
         Setters.setAccessControlManager(_accessControlManager);
 
-        TransmuterStorage storage ks = s.transmuterStorage();
-        ks.normalizer = uint128(BASE_27);
-        ks.agToken = IAgToken(_agToken);
+        TransmuterStorage storage ts = s.transmuterStorage();
+        ts.normalizer = uint128(BASE_27);
+        ts.agToken = IAgToken(_agToken);
 
         // Setup first collateral
         Setters.addCollateral(eurA.collateral);

--- a/contracts/transmuter/facets/Getters.sol
+++ b/contracts/transmuter/facets/Getters.sol
@@ -71,8 +71,8 @@ contract Getters is IGetters {
         view
         returns (uint64[] memory xRedemptionCurve, int64[] memory yRedemptionCurve)
     {
-        TransmuterStorage storage ks = s.transmuterStorage();
-        return (ks.xRedemptionCurve, ks.yRedemptionCurve);
+        TransmuterStorage storage ts = s.transmuterStorage();
+        return (ts.xRedemptionCurve, ts.yRedemptionCurve);
     }
 
     /// @inheritdoc IGetters
@@ -84,18 +84,18 @@ contract Getters is IGetters {
     function getIssuedByCollateral(
         address collateral
     ) external view returns (uint256 stablecoinsFromCollateral, uint256 stablecoinsIssued) {
-        TransmuterStorage storage ks = s.transmuterStorage();
-        uint256 _normalizer = ks.normalizer;
+        TransmuterStorage storage ts = s.transmuterStorage();
+        uint256 _normalizer = ts.normalizer;
         return (
-            (uint256(ks.collaterals[collateral].normalizedStables) * _normalizer) / BASE_27,
-            (uint256(ks.normalizedStables) * _normalizer) / BASE_27
+            (uint256(ts.collaterals[collateral].normalizedStables) * _normalizer) / BASE_27,
+            (uint256(ts.normalizedStables) * _normalizer) / BASE_27
         );
     }
 
     /// @inheritdoc IGetters
     function getTotalIssued() external view returns (uint256) {
-        TransmuterStorage storage ks = s.transmuterStorage();
-        return (uint256(ks.normalizedStables) * uint256(ks.normalizer)) / BASE_27;
+        TransmuterStorage storage ts = s.transmuterStorage();
+        return (uint256(ts.normalizedStables) * uint256(ts.normalizer)) / BASE_27;
     }
 
     /// @inheritdoc IGetters

--- a/contracts/transmuter/facets/RewardHandler.sol
+++ b/contracts/transmuter/facets/RewardHandler.sol
@@ -27,9 +27,9 @@ contract RewardHandler is IRewardHandler {
     /// @dev Only governance can set which tokens can be swapped through this function by passing a prior approval
     /// transaction to 1inch router for the token to be swapped
     function sellRewards(uint256 minAmountOut, bytes memory payload) external returns (uint256 amountOut) {
-        TransmuterStorage storage ks = s.transmuterStorage();
-        if (!LibDiamond.isGovernorOrGuardian(msg.sender) && ks.isSellerTrusted[msg.sender] == 0) revert NotTrusted();
-        address[] memory list = ks.collateralList;
+        TransmuterStorage storage ts = s.transmuterStorage();
+        if (!LibDiamond.isGovernorOrGuardian(msg.sender) && ts.isSellerTrusted[msg.sender] == 0) revert NotTrusted();
+        address[] memory list = ts.collateralList;
         uint256 listLength = list.length;
         uint256[] memory balances = new uint256[](listLength);
         // Getting the balances of all collateral assets of the protocol to see if those do not decrease during

--- a/contracts/transmuter/facets/SettersGuardian.sol
+++ b/contracts/transmuter/facets/SettersGuardian.sol
@@ -48,18 +48,18 @@ contract SettersGuardian is AccessControlModifiers, ISettersGuardian {
 
     /// @inheritdoc ISettersGuardian
     function setRedemptionCurveParams(uint64[] memory xFee, int64[] memory yFee) external onlyGuardian {
-        TransmuterStorage storage ks = s.transmuterStorage();
+        TransmuterStorage storage ts = s.transmuterStorage();
         LibSetters.checkFees(xFee, yFee, ActionType.Redeem);
-        ks.xRedemptionCurve = xFee;
-        ks.yRedemptionCurve = yFee;
+        ts.xRedemptionCurve = xFee;
+        ts.yRedemptionCurve = yFee;
         emit RedemptionCurveParamsSet(xFee, yFee);
     }
 
     /// @inheritdoc ISettersGuardian
     function toggleWhitelist(WhitelistType whitelistType, address who) external onlyGuardian {
-        TransmuterStorage storage ks = s.transmuterStorage();
-        uint256 whitelistStatus = 1 - ks.isWhitelistedForType[whitelistType][who];
-        ks.isWhitelistedForType[whitelistType][who] = whitelistStatus;
+        TransmuterStorage storage ts = s.transmuterStorage();
+        uint256 whitelistStatus = 1 - ts.isWhitelistedForType[whitelistType][who];
+        ts.isWhitelistedForType[whitelistType][who] = whitelistStatus;
         emit WhitelistStatusToggled(whitelistType, who, whitelistStatus);
     }
 }

--- a/test/fuzz/RedeemTest.t.sol
+++ b/test/fuzz/RedeemTest.t.sol
@@ -271,7 +271,7 @@ contract RedeemTest is Fixture, FunctionUtils {
         _assertSizes(tokens, amounts);
         _assertTransfers(alice, _collaterals, amounts);
 
-        // Testing implicitly the ks.normalizer and ks.normalizedStables
+        // Testing implicitly the ts.normalizer and ts.normalizedStables
         for (uint256 i; i < _collaterals.length; ++i) {
             (uint256 stableIssuedByCollateral, uint256 totalStable) = transmuter.getIssuedByCollateral(_collaterals[i]);
             assertApproxEqAbs(
@@ -329,7 +329,7 @@ contract RedeemTest is Fixture, FunctionUtils {
         _assertSizes(tokens, amounts);
         _assertTransfers(alice, _collaterals, amounts);
 
-        // Testing implicitly the ks.normalizer and ks.normalizedStables
+        // Testing implicitly the ts.normalizer and ts.normalizedStables
         for (uint256 i; i < _collaterals.length; ++i) {
             (uint256 stableIssuedByCollateral, uint256 totalStable) = transmuter.getIssuedByCollateral(_collaterals[i]);
             assertApproxEqAbs(
@@ -384,7 +384,7 @@ contract RedeemTest is Fixture, FunctionUtils {
             _assertSizes(tokens, amounts);
             _assertTransfers(alice, _collaterals, amounts);
 
-            // Testing implicitly the ks.normalizer and ks.normalizedStables
+            // Testing implicitly the ts.normalizer and ts.normalizedStables
             for (uint256 i; i < _collaterals.length; ++i) {
                 (uint256 stableIssuedByCollateral, uint256 totalStable) = transmuter.getIssuedByCollateral(
                     _collaterals[i]
@@ -397,7 +397,7 @@ contract RedeemTest is Fixture, FunctionUtils {
                 assertApproxEqAbs(totalStable, mintedStables - amountBurnt, 3 wei);
             }
             mintedStables = transmuter.getTotalIssued();
-            // now do a second redeem to test with non trivial ks.normalizer and ks.normalizedStables
+            // now do a second redeem to test with non trivial ts.normalizer and ts.normalizedStables
             vm.startPrank(bob);
             redeemProportion = bound(redeemProportion, 0, BASE_9);
             amountBurntBob = (agToken.balanceOf(bob) * redeemProportion) / BASE_9;
@@ -420,7 +420,7 @@ contract RedeemTest is Fixture, FunctionUtils {
             _assertTransfers(bob, _collaterals, amounts);
         }
 
-        // Testing implicitly the ks.normalizer and ks.normalizedStables
+        // Testing implicitly the ts.normalizer and ts.normalizedStables
         uint256 totalStable2;
         for (uint256 i; i < _collaterals.length; ++i) {
             uint256 stableIssuedByCollateral;
@@ -582,7 +582,7 @@ contract RedeemTest is Fixture, FunctionUtils {
                 address[] memory forfeitTokens;
                 _assertTransfersWithManager(alice, _collaterals, forfeitTokens, amounts);
             }
-            // Testing implicitly the ks.normalizer and ks.normalizedStables
+            // Testing implicitly the ts.normalizer and ts.normalizedStables
             for (uint256 i; i < _collaterals.length; ++i) {
                 (uint256 stableIssuedByCollateral, uint256 totalStable) = transmuter.getIssuedByCollateral(
                     _collaterals[i]
@@ -596,7 +596,7 @@ contract RedeemTest is Fixture, FunctionUtils {
             }
             mintedStables = transmuter.getTotalIssued();
 
-            // now do a second redeem to test with non trivial ks.normalizer and ks.normalizedStables
+            // now do a second redeem to test with non trivial ts.normalizer and ts.normalizedStables
             vm.startPrank(bob);
             redeemProportion = bound(redeemProportion, 0, BASE_9);
             amountBurntBob = (agToken.balanceOf(bob) * redeemProportion) / BASE_9;
@@ -623,7 +623,7 @@ contract RedeemTest is Fixture, FunctionUtils {
             }
         }
 
-        // Testing implicitly the ks.normalizer and ks.normalizedStables
+        // Testing implicitly the ts.normalizer and ts.normalizedStables
         uint256 totalStable2;
         for (uint256 i; i < _collaterals.length; ++i) {
             uint256 stableIssuedByCollateral;
@@ -723,7 +723,7 @@ contract RedeemTest is Fixture, FunctionUtils {
             _assertSizesWithManager(tokens, amounts);
             _assertTransfersWithManager(alice, _collaterals, forfeitTokens, amounts);
 
-            // Testing implicitly the ks.normalizer and ks.normalizedStables
+            // Testing implicitly the ts.normalizer and ts.normalizedStables
             for (uint256 i; i < _collaterals.length; ++i) {
                 (uint256 stableIssuedByCollateral, uint256 totalStable) = transmuter.getIssuedByCollateral(
                     _collaterals[i]
@@ -737,7 +737,7 @@ contract RedeemTest is Fixture, FunctionUtils {
             }
             mintedStables = transmuter.getTotalIssued();
 
-            // now do a second redeem to test with non trivial ks.normalizer and ks.normalizedStables
+            // now do a second redeem to test with non trivial ts.normalizer and ts.normalizedStables
             vm.startPrank(bob);
             redeemProportion = bound(redeemProportion, 0, BASE_9);
             amountBurntBob = (agToken.balanceOf(bob) * redeemProportion) / BASE_9;
@@ -763,7 +763,7 @@ contract RedeemTest is Fixture, FunctionUtils {
             }
         }
 
-        // Testing implicitly the ks.normalizer and ks.normalizedStables
+        // Testing implicitly the ts.normalizer and ts.normalizedStables
         {
             uint256 totalStable2;
             for (uint256 i; i < _collaterals.length; ++i) {
@@ -838,7 +838,7 @@ contract RedeemTest is Fixture, FunctionUtils {
         _assertSizes(tokens, amounts);
         _assertTransfers(alice, _collaterals, amounts);
 
-        // Testing implicitly the ks.normalizer and ks.normalizedStables
+        // Testing implicitly the ts.normalizer and ts.normalizedStables
         for (uint256 i; i < _collaterals.length; ++i) {
             (uint256 stableIssuedByCollateral, uint256 totalStable) = transmuter.getIssuedByCollateral(_collaterals[i]);
             assertApproxEqAbs(


### PR DESCRIPTION
- Replaces all occurrences of ks (Kheops Storage) with ts (Transmuter Storage)
- Ran the tests (yarn test) after replacing all occurrences (all tests passed)